### PR TITLE
Stop tracking wpilib by tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: java
-install: git clone https://github.com/chopshop-166/wpilib-mirror.git ~/wpilib -b v2016
+install: git clone https://github.com/chopshop-166/wpilib-mirror.git ~/wpilib
 script: ant jar
 jdk: oraclejdk8


### PR DESCRIPTION
Just use ~master, it'll stay up to date
